### PR TITLE
Add Vending Machine v2

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,3 +1,10 @@
 TESTNET_ALCHEMY_RPC_URL=alchemy_rpc_url
 TESTNET_WALLET_PRIVATE_KEY=your_test_wallet_private_key
 ETHERSCAN_KEY=your_etherscan_api_key
+# NOTE: `scripts/upgradeProxy.js` defaults to the Goerli proxy address; if the
+#       Hardhat network is set to `mainnet` then the `PROXY_ADDRESS` will be
+#       used.
+PROXY_GOERLI_ADDRESS=0xE6800bcaf26F61Ad1525dF9941dF3899F8194586
+# TODO: once deployed to mainnet, set this value and commit it to `.env-sample`.
+#       (this is a safe-to-commit value)
+PROXY_ADDRESS=change_this_to_the_mainnet_proxy_address_and_commit_to_sample

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage
 coverage.json
 typechain
 typechain-types
+.openzeppelin/unknown-*.json
 
 # Hardhat files
 cache

--- a/.openzeppelin/goerli.json
+++ b/.openzeppelin/goerli.json
@@ -71,6 +71,78 @@
           }
         }
       }
+    },
+    "16929cbd86bab36692ef070a60c8221aaf84ec0096f8c7223ded9ff9a41381a3": {
+      "address": "0xDeE9b98a78E21a26B445feBdFfAac227d549311b",
+      "txHash": "0xabd80672059fe358580d09bbc38981936557f7d892500fec9b8464e762090a8f",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "numSodas",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256",
+            "contract": "VendingMachineV2",
+            "src": "contracts/VendingMachineV2.sol:9"
+          },
+          {
+            "label": "owner",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_address",
+            "contract": "VendingMachineV2",
+            "src": "contracts/VendingMachineV2.sol:10"
+          },
+          {
+            "label": "purchasedSodas",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "VendingMachineV2",
+            "src": "contracts/VendingMachineV2.sol:11"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - [`0xE6800bcaf26F61Ad1525dF9941dF3899F8194586`](https://goerli.etherscan.io/address/0xe6800bcaf26f61ad1525df9941df3899f8194586)
 - **Implementation contract address:**
   - **V1:** [`0x3856aFA22Ed9DF76Fffb7d49573F95DDB21B665E`](https://goerli.etherscan.io/address/0x3856afa22ed9df76fffb7d49573f95ddb21b665e)
+  - **V2:** [`0xdee9b98a78e21a26b445febdffaac227d549311b`](https://goerli.etherscan.io/address/0xdee9b98a78e21a26b445febdffaac227d549311b)
 
 ## Sample Hardhat Project
 

--- a/contracts/VendingMachineV2.sol
+++ b/contracts/VendingMachineV2.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract VendingMachineV2 is Initializable {
+  // these state variables and their values will be preserved forever,
+  // regardless of contract upgrades.
+  uint public numSodas;
+  address public owner;
+  mapping(address => uint) public purchasedSodas;
+
+  function initialize(uint _numSodas) public initializer {
+    numSodas = _numSodas;
+    owner = msg.sender;
+  }
+
+  event SodaPurchased(address _customer);
+
+  function purchaseSoda() public payable inStock {
+    require(msg.value >= 1000 wei, "You must pay 1000 wei for a soda!");
+    numSodas--;
+    purchasedSodas[msg.sender]++;
+    emit SodaPurchased(msg.sender);
+  }
+
+  modifier inStock() {
+    require(numSodas > 0, "There are no more sodas to buy!");
+    _;
+  }
+
+  function withdrawProfits() public onlyOwner {
+    require(
+      address(this).balance > 0,
+      "Profits must be greater than 0 in order to withdraw!"
+    );
+    (bool sent, ) = owner.call{value: address(this).balance}("");
+    require(sent, "Failed to send ether to owner");
+  }
+
+  event NewOwnerSet(address _owner, address _newOwner);
+
+  function setNewOwner(address _newOwner) public onlyOwner {
+    owner = _newOwner;
+    emit NewOwnerSet(owner, _newOwner);
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "Only owner can call this function.");
+    _;
+  }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,7 +7,6 @@ require("@nomiclabs/hardhat-ethers");
 /** @type import('hardhat/config').HardhatUserConfig */
 module.exports = {
   solidity: "0.8.17",
-  defaultNetwork: "localhost",
   networks: {
     goerli: {
       url: process.env.TESTNET_ALCHEMY_RPC_URL,

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "compile": "npx hardhat compile",
     "deploy_local": "npx hardhat run scripts/deployProxy.js --network localhost",
     "deploy_goerli": "npx hardhat run scripts/deployProxy.js --network goerli",
+    "upgrade_local": "npx hardhat run scripts/upgradeProxy.js --network localhost",
+    "upgrade_goerli": "npx hardhat run scripts/upgradeProxy.js --network goerli",
     "verify_goerli": "npx hardhat verify --network goerli",
     "test": "npx hardhat test"
   },

--- a/scripts/upgradeProxy.js
+++ b/scripts/upgradeProxy.js
@@ -1,0 +1,25 @@
+require("dotenv").config();
+const { ethers, upgrades } = require("hardhat");
+const hre = require("hardhat");
+const networkName = hre.network.name;
+
+async function main() {
+  let proxyAddress = process.env.PROXY_GOERLI_ADDRESS;
+  if (networkName == "mainnet") {
+    proxyAddress = process.env.PROXY_ADDRESS;
+  }
+
+  const VendingMachineV2 = await ethers.getContractFactory("VendingMachineV2");
+  const upgraded = await upgrades.upgradeProxy(proxyAddress, VendingMachineV2);
+  const implementationAddress = await upgrades.erc1967.getImplementationAddress(
+    proxyAddress
+  );
+
+  const owner = await upgraded.owner();
+  console.log("The current contract owner is: " + owner);
+  // TODO: this gave the previous implementation address; find a way to make
+  // this script wait long enough to get the correct address. [topher]
+  console.log("Implementation contract address: " + implementationAddress);
+}
+
+main();

--- a/test/testUpgradingV1ToV2.js
+++ b/test/testUpgradingV1ToV2.js
@@ -1,0 +1,39 @@
+const { expect } = require("chai");
+
+describe("UpgradingV1ToV2", function () {
+  it("should upgrade from v1 to v2", async function () {
+    const [user] = await ethers.getSigners();
+    const VendingMachineV1 = await ethers.getContractFactory(
+      "VendingMachineV1"
+    );
+    const VendingMachineV2 = await ethers.getContractFactory(
+      "VendingMachineV2"
+    );
+    const proxy = await upgrades.deployProxy(VendingMachineV1, [100]);
+    const v1Address = await upgrades.erc1967.getImplementationAddress(
+      proxy.address
+    );
+    await proxy.deployed();
+
+    // should start with the 100 sodas
+    expect(await proxy.numSodas()).to.equal(100);
+    // should decrement after a soda purchase
+    await proxy
+      .connect(user)
+      .purchaseSoda({ value: ethers.utils.parseUnits("1000", "wei") });
+    expect(await proxy.numSodas()).to.equal(99);
+
+    const upgraded = await upgrades.upgradeProxy(
+      proxy.address,
+      VendingMachineV2
+    );
+    // should still equal 99 sodas
+    expect(await upgraded.numSodas()).to.equal(99);
+
+    // the implementation address should have changed
+    const v2Address = await upgrades.erc1967.getImplementationAddress(
+      proxy.address
+    );
+    expect(v1Address).to.not.equal(v2Address);
+  });
+});

--- a/test/testVendingMachineV2.js
+++ b/test/testVendingMachineV2.js
@@ -1,0 +1,44 @@
+const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
+const { expect } = require("chai");
+
+describe("VendingMachineV2", function () {
+  // This fixture will be re-run in every test to setup the contract.
+  // Using loadFixture() to run this will create a snapshot of the contract
+  // state and reset the Hardhat Network to that snapshot in every test.
+  async function deployContractAndSetVariables() {
+    const [owner, user1, user2] = await ethers.getSigners();
+    const VendingMachineV2 = await ethers.getContractFactory(
+      "VendingMachineV2"
+    );
+    // deploy the with the starting soda count of 100
+    // TODO: will I need to call `initialize()` instead of `deploy`? See
+    // deployProxy for possible ways for testing this correctly. [topher]
+    const vendingMachineV2 = await VendingMachineV2.deploy(100);
+    return { owner, user1, user2, vendingMachineV2 };
+  }
+
+  it("should initialize the owner", async function () {
+    // TODO
+  });
+  it("should initialize the correct soda count", async function () {
+    // TODO
+  });
+  it("should increment purchasedSodas", async function () {
+    // TODO
+  });
+  it("should emit SodaPurchased event", async function () {
+    // TODO
+  });
+  it("should prevent purchasing sodas when numSodas is zero", async function () {
+    // TODO
+  });
+  it("should restrict withdrawProfits to the owner", async function () {
+    // TODO
+  });
+  it("should only allow the owner to setNewOwner", async function () {
+    // TODO
+  });
+  it("should emit NewOwnerSet event", async function () {
+    // TODO
+  });
+});

--- a/test/testVendingMachineV2.js
+++ b/test/testVendingMachineV2.js
@@ -1,44 +1,160 @@
 const { loadFixture } = require("@nomicfoundation/hardhat-network-helpers");
-const { expect } = require("chai");
+const { assert, expect } = require("chai");
 
 describe("VendingMachineV2", function () {
   // This fixture will be re-run in every test to setup the contract.
   // Using loadFixture() to run this will create a snapshot of the contract
   // state and reset the Hardhat Network to that snapshot in every test.
-  async function deployContractAndSetVariables() {
+  async function upgradeContractAndSetVariables() {
     const [owner, user1, user2] = await ethers.getSigners();
+
+    // deploy the v1 contract with 10 sodas
+    const VendingMachineV1 = await ethers.getContractFactory(
+      "VendingMachineV1"
+    );
+    const proxy = await upgrades.deployProxy(VendingMachineV1, [10]);
+    await proxy.deployed();
+
+    // upgrade to v2 contract
     const VendingMachineV2 = await ethers.getContractFactory(
       "VendingMachineV2"
     );
-    // deploy the with the starting soda count of 100
-    // TODO: will I need to call `initialize()` instead of `deploy`? See
-    // deployProxy for possible ways for testing this correctly. [topher]
-    const vendingMachineV2 = await VendingMachineV2.deploy(100);
-    return { owner, user1, user2, vendingMachineV2 };
+    const upgradedProxy = await upgrades.upgradeProxy(
+      proxy.address,
+      VendingMachineV2
+    );
+    return { owner, user1, user2, upgradedProxy };
   }
 
   it("should initialize the owner", async function () {
-    // TODO
+    const { owner, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+    expect(await upgradedProxy.owner()).to.equal(owner.address);
   });
+
   it("should initialize the correct soda count", async function () {
-    // TODO
+    const { upgradedProxy } = await loadFixture(upgradeContractAndSetVariables);
+    expect(await upgradedProxy.numSodas()).to.equal(10);
   });
-  it("should increment purchasedSodas", async function () {
-    // TODO
+
+  it("should increment purchasedSodas and decrement numSodas", async function () {
+    const { user1, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+    expect(await upgradedProxy.purchasedSodas(user1.address)).to.equal(0);
+
+    await upgradedProxy
+      .connect(user1)
+      .purchaseSoda({ value: ethers.utils.parseUnits("1000", "wei") });
+    expect(await upgradedProxy.numSodas()).to.equal(9);
+    expect(await upgradedProxy.purchasedSodas(user1.address)).to.equal(1);
   });
+
   it("should emit SodaPurchased event", async function () {
-    // TODO
+    const { user1, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+    const response = await upgradedProxy
+      .connect(user1)
+      .purchaseSoda({ value: ethers.utils.parseUnits("1000", "wei") });
+    const receipt = await response.wait();
+    const topic = upgradedProxy.interface.getEventTopic("SodaPurchased");
+    const log = receipt.logs.find((x) => x.topics.indexOf(topic) >= 0);
+    deployedEvent = upgradedProxy.interface.parseLog(log);
+    assert(deployedEvent, "Expected a SodaPurchased event to be emitted!");
   });
+
   it("should prevent purchasing sodas when numSodas is zero", async function () {
-    // TODO
+    const { user1, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+    expect(await upgradedProxy.numSodas()).to.equal(10);
+    expect(await upgradedProxy.purchasedSodas(user1.address)).to.equal(0);
+    for (let i = 1; i <= 10; i++) {
+      await upgradedProxy
+        .connect(user1)
+        .purchaseSoda({ value: ethers.utils.parseUnits("1000", "wei") });
+      expect(await upgradedProxy.purchasedSodas(user1.address)).to.equal(i);
+    }
+    expect(await upgradedProxy.numSodas()).to.equal(0);
+    expect(await upgradedProxy.purchasedSodas(user1.address)).to.equal(10);
+
+    // should now prevent purchasing a soda
+    await expect(
+      upgradedProxy
+        .connect(user1)
+        .purchaseSoda({ value: ethers.utils.parseUnits("1000", "wei") })
+    ).to.be.revertedWith("There are no more sodas to buy!");
   });
+
+  it("should restrict withdrawProfits to when a balance exists", async function () {
+    const { owner, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+    const balance = await ethers.provider.getBalance(upgradedProxy.address);
+    expect(balance.eq(0)).to.equal(true);
+    await expect(
+      upgradedProxy.connect(owner).withdrawProfits()
+    ).to.be.revertedWith(
+      "Profits must be greater than 0 in order to withdraw!"
+    );
+  });
+
   it("should restrict withdrawProfits to the owner", async function () {
-    // TODO
+    const { owner, user1, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+
+    // starting balance will be 1000 wei
+    await upgradedProxy
+      .connect(user1)
+      .purchaseSoda({ value: ethers.utils.parseUnits("1000", "wei") });
+    const balanceStart = await ethers.provider.getBalance(
+      upgradedProxy.address
+    );
+    expect(balanceStart.eq(ethers.utils.parseUnits("1000", "wei"))).to.equal(
+      true
+    );
+
+    // restricted to owner
+    await expect(
+      upgradedProxy.connect(user1).withdrawProfits()
+    ).to.be.revertedWith("Only owner can call this function.");
+
+    // ending balance should be 0 after withdrawProfits()
+    await upgradedProxy.connect(owner).withdrawProfits();
+    const balanceEnd = await ethers.provider.getBalance(upgradedProxy.address);
+    expect(balanceEnd.eq(0)).to.equal(true);
   });
+
   it("should only allow the owner to setNewOwner", async function () {
-    // TODO
+    const { owner, user1, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+
+    expect(await upgradedProxy.owner()).to.equal(owner.address);
+
+    // restricted to owner
+    await expect(
+      upgradedProxy.connect(user1).setNewOwner(user1.address)
+    ).to.be.revertedWith("Only owner can call this function.");
+
+    await upgradedProxy.connect(owner).setNewOwner(user1.address);
+    expect(await upgradedProxy.owner()).to.equal(user1.address);
   });
+
   it("should emit NewOwnerSet event", async function () {
-    // TODO
+    const { owner, user1, upgradedProxy } = await loadFixture(
+      upgradeContractAndSetVariables
+    );
+    const response = await upgradedProxy
+      .connect(owner)
+      .setNewOwner(user1.address);
+    const receipt = await response.wait();
+    const topic = upgradedProxy.interface.getEventTopic("NewOwnerSet");
+    const log = receipt.logs.find((x) => x.topics.indexOf(topic) >= 0);
+    deployedEvent = upgradedProxy.interface.parseLog(log);
+    assert(deployedEvent, "Expected a NewOwnerSet event to be emitted!");
   });
 });


### PR DESCRIPTION
## New

* Create new `VendingMachineV2.sol` contract to address the following:
  - 🐛 [Issue #2 - add owner restricted `withdrawProfits()` function](https://github.com/skplunkerin/upgradeable_vending_machine_contract--alchemy_university/issues/2)
  - [Issue #3 - track users amount of sodas purchased](https://github.com/skplunkerin/upgradeable_vending_machine_contract--alchemy_university/issues/3)
  - 🐛 [Issue #4 - prevent buying a soda when `numSodas == 0`](https://github.com/skplunkerin/upgradeable_vending_machine_contract--alchemy_university/issues/4)

* Add tests for:
  - New `UpgradingV1ToV2` test case:
    - should upgrade from v1 to v2
  - New `VendingMachineV2` test cases:
    - should initialize the owner
    - should initialize the correct soda count
    - should increment purchasedSodas and decrement numSodas
    - should emit SodaPurchased event
    - should prevent purchasing sodas when numSodas is zero
    - should restrict withdrawProfits to when a balance exists
    - should restrict withdrawProfits to the owner
    - should only allow the owner to setNewOwner
    - should emit NewOwnerSet event

* Add `upgradeProxy.js` script 
  - Run the script on `Goerli`


## Updates

* update `README.md` and `.openzeppelin/goerli.json` with new
   implementation address details

* Remove `defaultNetwork: "localhost"` from `hardhat.config.js` to allow 
  tests to run on the hardhat `defaultNetwork`

* Add `.openzeppelin/unknown-*.json` to `.gitignore`

* Update `.env-sample` with proxy address variables

* Add upgrade script declarations in `package.json`


## Fixes

* Fix the following issues:
  - [Issue #2 - add owner restricted `withdrawProfits()` function](https://github.com/skplunkerin/upgradeable_vending_machine_contract--alchemy_university/issues/2)
  - [Issue #4 - prevent buying a soda when `numSodas == 0`](https://github.com/skplunkerin/upgradeable_vending_machine_contract--alchemy_university/issues/4)
